### PR TITLE
STM32/RealProjects/STM32_Dune

### DIFF
--- a/STM32/RealProjects/STM32_Dune/EXT/ST7735/st7735.c
+++ b/STM32/RealProjects/STM32_Dune/EXT/ST7735/st7735.c
@@ -41,6 +41,13 @@ uint16_t scr_height;
 *                           Local functions
 *--------------------------------------------------------------------------------*/
 
+void Delay_US(__IO uint32_t nTime)
+{
+    __IO uint32_t delayTicks = (10000 * nTime);
+    for(uint32_t i=0; i<delayTicks; i++)
+        __nop();
+}
+
 /*--------------------------------------------------------------------------------
 @name		  
 @brief		

--- a/STM32/RealProjects/STM32_Dune/EXT/ST7735/st7735.h
+++ b/STM32/RealProjects/STM32_Dune/EXT/ST7735/st7735.h
@@ -114,7 +114,4 @@ void ST7735_PutInt5x7(uint8_t scale, uint8_t X, uint8_t Y, int value, uint16_t c
 void ST7735_PutFloat7x11(uint8_t X, uint8_t Y, float value, uint8_t precision, uint16_t color, uint16_t bgcolor);
 void ST7735_PutFloat5x7(uint8_t scale, uint8_t X, uint8_t Y, float value, uint8_t precision, uint16_t color, uint16_t bgcolor);
 
-// delay function from main.c
-extern void Delay_US(__IO uint32_t nTime);
-
 #endif

--- a/STM32/RealProjects/STM32_Dune/SWC/DISPLAY/Display.c
+++ b/STM32/RealProjects/STM32_Dune/SWC/DISPLAY/Display.c
@@ -59,13 +59,3 @@ void Display_InitRunnable(void)
     ST7735_Clear(COLOR565_RED);
 }
 
-/*--------------------------------------------------------------------------------
-@name		Delay_US
-@brief		Delay execution for delayTime milliseconds
-@paramIn	U32 delayTime: time to be delayed
-@paramOut	void
-*--------------------------------------------------------------------------------*/
-void Delay_US(__IO uint32_t nTime)
-{
-    Timer_Delay_MS(nTime);
-}


### PR DESCRIPTION
[Bugfix]
 - The ST7735 display driver had a dependency on Display software component.
 - The dependency was Delay_US() function which was removed from Display.c and defined in st7735.c file